### PR TITLE
The specified charge is now passed on to the xTB Calculator

### DIFF
--- a/pygsm/level_of_theories/xtb_lot.py
+++ b/pygsm/level_of_theories/xtb_lot.py
@@ -37,8 +37,7 @@ class xTB_lot(Lot):
 
         # convert to bohr
         positions = coords* units.ANGSTROM_TO_AU
-
-        calc = Calculator(get_method("GFN2-xTB"), self.numbers, positions)
+        calc = Calculator(get_method("GFN2-xTB"), self.numbers, positions, charge=self.charge)
         calc.set_output('lot_jobs_{}.txt'.format(self.node_id))
         res = calc.singlepoint()  # energy printed is only the electronic part
         calc.release_output()


### PR DESCRIPTION
The xTB Calculator object accepts the charge as optional argument. Since the charge is already in the xTB_lot object, it can directly to passed on to support charged systems.