### PR TITLE
Added option to output structures as standard multi-xyz files

### DIFF
--- a/pygsm/growing_string_methods/de_gsm.py
+++ b/pygsm/growing_string_methods/de_gsm.py
@@ -10,7 +10,6 @@ import numpy as np
 # local application imports
 sys.path.append(path.dirname( path.dirname( path.abspath(__file__))))
 from utilities import *
-from utilities.manage_xyz import write_molden_geoms
 from wrappers import Molecule
 try:
     from .main_gsm import MainGSM
@@ -55,7 +54,7 @@ class DE_GSM(MainGSM):
 
             #nifty.printcool("initial ic_reparam")
             self.reparameterize()
-            write_molden_geoms('grown_string_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
+            self.xyz_writer('grown_string_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
 
         
         # Can check for intermediate at beginning but not doing that now.
@@ -85,7 +84,7 @@ class DE_GSM(MainGSM):
 
         filename="opt_converged_{:03d}.xyz".format(self.ID)
         print(" Printing string to " + filename)
-        write_molden_geoms(filename,self.geometries,self.energies,self.gradrmss,self.dEs)
+        self.xyz_writer(filename,self.geometries,self.energies,self.gradrmss,self.dEs)
         print("Finished GSM!") 
 
         return 

--- a/pygsm/growing_string_methods/gsm.py
+++ b/pygsm/growing_string_methods/gsm.py
@@ -14,6 +14,7 @@ from itertools import chain
 # local application imports
 sys.path.append(path.dirname( path.dirname( path.abspath(__file__))))
 from utilities import nifty,options,manage_xyz
+from utilities.manage_xyz import write_molden_geoms
 from wrappers import Molecule
 from coordinate_systems import DelocalizedInternalCoordinates
 from optimizers._linesearch import double_golden_section
@@ -146,6 +147,13 @@ class GSM(object):
                 )
 
         opt.add_option(
+                key='xyz_writer',
+                value=write_molden_geoms,
+                required=False,
+                doc='Function to be used to format and write XYZ files',
+                )
+
+        opt.add_option(
                 key='mp_cores',
                 value=1,
                 doc='multiprocessing cores for parallel programming. Use this with caution.',
@@ -223,6 +231,7 @@ class GSM(object):
         self.CONV_TOL = self.options['CONV_TOL']
         self.noise = self.options['noise']
         self.mp_cores = self.options['mp_cores']
+        self.xyz_writer = self.options['xyz_writer']
 
         optimizer = options['optimizer']
         for count in range(self.nnodes):

--- a/pygsm/growing_string_methods/main_gsm.py
+++ b/pygsm/growing_string_methods/main_gsm.py
@@ -54,7 +54,7 @@ class MainGSM(GSM):
             printcool("Starting growth iteration %i" % iteration)
             self.optimize_iteration(max_opt_steps)
             totalgrad,gradrms,sum_gradrms = self.calc_optimization_metrics(self.nodes)
-            write_molden_geoms('scratch/growth_iters_{:03}_{:03}.xyz'.format(self.ID,iteration),self.geometries,self.energies,self.gradrmss,self.dEs)
+            self.xyz_writer('scratch/growth_iters_{:03}_{:03}.xyz'.format(self.ID,iteration),self.geometries,self.energies,self.gradrmss,self.dEs)
             print(" gopt_iter: {:2} totalgrad: {:4.3} gradrms: {:5.4} max E: {:5.4}\n".format(iteration,float(totalgrad),float(gradrms),float(self.emax)))
                 
             try:
@@ -250,7 +250,7 @@ class MainGSM(GSM):
 
             # => write Convergence to file <= #
             filename = 'scratch/opt_iters_{:03}_{:03}.xyz'.format(self.ID,oi)
-            write_molden_geoms(filename,self.geometries,self.energies,self.gradrmss,self.dEs)
+            self.xyz_writer(filename,self.geometries,self.energies,self.gradrmss,self.dEs)
 
             print(" End early counter {}".format(self.endearly_counter))
 
@@ -1195,7 +1195,7 @@ class MainGSM(GSM):
         if reparametrize:
             printcool("Reparametrizing")
             self.reparameterize(ic_reparam_steps=8)
-            write_molden_geoms('grown_string_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
+            self.xyz_writer('grown_string_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
 
         if restart_energies:
             # initial energy

--- a/pygsm/growing_string_methods/se_cross.py
+++ b/pygsm/growing_string_methods/se_cross.py
@@ -13,7 +13,6 @@ from utilities import *
 from wrappers import Molecule
 from .se_gsm import SE_GSM
 from potential_energy_surfaces import Avg_PES,PES
-from utilities.manage_xyz import write_molden_geoms
 
 
 class SE_Cross(SE_GSM):
@@ -82,7 +81,7 @@ class SE_Cross(SE_GSM):
                     path=path,
                     )
 
-        write_molden_geoms('after_penalty_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
+        self.xyz_writer('after_penalty_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
         self.optimizer[self.nR].opt_cross=True
         self.nodes[0].V0 = self.nodes[0].PES.PES2.energy 
         if rtype==0:
@@ -134,7 +133,7 @@ class SE_Cross(SE_GSM):
                     verbose=True,
                     path=path,
                     )
-        write_molden_geoms('grown_string_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
+        self.xyz_writer('grown_string_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
 
         if self.optimizer[self.nR].converged:
             self.nnodes=self.nR+1
@@ -157,7 +156,7 @@ class SE_Cross(SE_GSM):
             for n in range(self.nnodes):
                 print(" {:7.3f}".format(float(energies[n])), end=' ')
             print()
-            write_molden_geoms('grown_string1_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
+            self.xyz_writer('grown_string1_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
    
             deltaE = energies[-1] - energies[0]
             if deltaE>20:

--- a/pygsm/growing_string_methods/se_gsm.py
+++ b/pygsm/growing_string_methods/se_gsm.py
@@ -14,7 +14,6 @@ from utilities import *
 from wrappers import Molecule
 from .main_gsm import MainGSM
 from coordinate_systems import Distance,Angle,Dihedral,OutOfPlane,TranslationX,TranslationY,TranslationZ,RotationA,RotationB,RotationC
-from utilities.manage_xyz import write_molden_geoms
 
 
 class SE_GSM(MainGSM):
@@ -136,7 +135,7 @@ class SE_GSM(MainGSM):
 
             print(" Number of nodes is ",self.nnodes)
             print(" Warning last node still not optimized fully")
-            write_molden_geoms('grown_string_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
+            self.xyz_writer('grown_string_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
             print(" SSM growth phase over")
             self.done_growing=True
 
@@ -155,7 +154,7 @@ class SE_GSM(MainGSM):
             for n in range(self.nnodes):
                 print(" {:7.3f}".format(float(energies[n])), end=' ')
             print()
-            write_molden_geoms('grown_string1_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
+            self.xyz_writer('grown_string1_{:03}.xyz'.format(self.ID),self.geometries,self.energies,self.gradrmss,self.dEs)
 
         if self.tscontinue:
             self.optimize_string(max_iter=max_iters,opt_steps=3,rtype=rtype) #opt steps fixed at 3 for rtype=1 and 2, else set it to be the large number :) muah hahaahah
@@ -165,7 +164,7 @@ class SE_GSM(MainGSM):
 
         filename="opt_converged_{:03d}.xyz".format(self.ID)
         print(" Printing string to " + filename)
-        write_molden_geoms(filename,self.geometries,self.energies,self.gradrms,self.dEs)
+        self.xyz_writer(filename,self.geometries,self.energies,self.gradrms,self.dEs)
         print("Finished GSM!")  
 
 

--- a/pygsm/utilities/manage_xyz.py
+++ b/pygsm/utilities/manage_xyz.py
@@ -8,7 +8,6 @@ import re
 #import openbabel as ob
 
 # => XYZ File Utility <= #
-
 def read_xyz(
     filename, 
     scale=1.):
@@ -241,6 +240,25 @@ def write_xyzs(
                 scale*atom[3],
                 ))
 
+def write_std_multixyz(
+        filename,
+        geoms,
+        energies,
+        gradrms,
+        dEs,
+        ):
+        with open(filename,'w') as f:
+            for E, geom in zip(energies, geoms):
+                f.write('%d\n' % len(geom))
+                f.write('%.6f\n' % (E*units.KJ_MOL_TO_AU))
+                for atom in geom:
+                    f.write('%-2s %14.6f %14.6f %14.6f\n' % (
+                        atom[0],
+                        atom[1],
+                        atom[2],
+                        atom[3],
+                        ))
+
 def write_amber_xyz(
         filename,
         geom,
@@ -391,3 +409,8 @@ def write_fms90(
                 atom[2],
                 atom[3],
                 ))
+XYZ_WRITERS = {
+    'molden': write_molden_geoms,
+    'multixyz': write_std_multixyz,
+}
+

--- a/pygsm/wrappers/main.py
+++ b/pygsm/wrappers/main.py
@@ -15,6 +15,8 @@ import textwrap
 # local application imports
 sys.path.append(path.dirname( path.dirname( path.abspath(__file__))))
 from utilities import *
+from utilities.manage_xyz import XYZ_WRITERS
+
 from potential_energy_surfaces import PES,Avg_PES,Penalty_PES
 from wrappers import Molecule
 from optimizers import *
@@ -48,6 +50,7 @@ def main():
     parser.add_argument('-optimizer',type=str,default='eigenvector_follow',help='The optimizer object. (default: %(default)s Recommend LBFGS for large molecules >1000 atoms)',required=False)
     parser.add_argument('-opt_print_level',type=int,default=1,help='Printout for optimization. 2 prints everything in opt.',required=False)
     parser.add_argument('-gsm_print_level',type=int,default=1,help='Printout for gsm. 1 prints ?',required=False)
+    parser.add_argument('-xyz_output_format',type=str,default="molden",help='Format of the produced XYZ files',required=False)
     parser.add_argument('-linesearch',type=str,default='NoLineSearch',help='default: %(default)s',choices=['NoLineSearch','backtrack'])
     parser.add_argument('-coordinate_type',type=str,default='TRIC',help='Coordinate system (default %(default)s)',choices=['TRIC','DLC','HDLC'])
     parser.add_argument('-ADD_NODE_TOL',type=float,default=0.01,help='Convergence tolerance for adding new node (default: %(default)s)',required=False)
@@ -124,6 +127,9 @@ def main():
               'opt_print_level' : args.opt_print_level,
               'linesearch' : args.linesearch,
               'DMAX'    :   args.DMAX,
+
+              #output
+              'xyz_output_format': args.xyz_output_format,
 
               #molecule
               'coordinate_type' : args.coordinate_type,
@@ -455,6 +461,7 @@ def main():
             #opt_climb = True if args.only_climb else False,
             )
 
+    
     # GSM
     nifty.printcool("Building the GSM object")
     gsm_class = getattr(sys.modules[__name__], inpfileq['gsm_type'])
@@ -472,6 +479,7 @@ def main():
                 optimizer=optimizer,
                 ID=inpfileq['ID'],
                 print_level=inpfileq['gsm_print_level'],
+                xyz_writer=XYZ_WRITERS[inpfileq['xyz_output_format']],
                 mp_cores=args.mp_cores,
                 interp_method = args.interp_method,
                 )
@@ -487,6 +495,7 @@ def main():
                 print_level=inpfileq['gsm_print_level'],
                 driving_coords=driving_coordinates,
                 ID=inpfileq['ID'],
+                xyz_writer=XYZ_WRITERS[inpfileq['xyz_output_format']],
                 mp_cores=args.mp_cores,
                 interp_method = args.interp_method,
                 )


### PR DESCRIPTION
Some molecular viewers cannot read the molden output files produced by pyGSM. I added an option to instead create multi-xyz files containing the relative energies as comments (which are sometimes parsed automatically).

The suggested code works, but you might want to refactor the functions in `utilities.manage_xyz`; I didn't want to mess too much with your other functions that write XYZ files, so I added a new one that takes the same parameters as `write_molden_geoms`.