### PR TITLE
Added solvation for xTB

### DIFF
--- a/pygsm/level_of_theories/base_lot.py
+++ b/pygsm/level_of_theories/base_lot.py
@@ -174,6 +174,14 @@ class Lot(object):
                 doc='xTB electronic_temperature'
                 )
 
+        opt.add_option(
+                key='solvent',
+                value=None,
+                required=False,
+                allowed_types=[str],
+                doc='xTB solvent'
+                )
+
         Lot._default_options = opt
         return Lot._default_options.copy()
 
@@ -181,9 +189,7 @@ class Lot(object):
             options,
             ):
         """ Constructor """
-
         self.options = options
-
         # properties
         self.Energy = namedtuple('Energy','value unit')
         self.Gradient = namedtuple('Gradient','value unit')
@@ -248,6 +254,7 @@ class Lot(object):
         self.xTB_Hamiltonian = self.options['xTB_Hamiltonian']
         self.xTB_accuracy = self.options['xTB_accuracy']
         self.xTB_electronic_temperature = self.options['xTB_electronic_temperature']
+        self.solvent = self.options['solvent']
 
         # Bools for running 
         self.hasRanForCurrentCoords =False

--- a/pygsm/level_of_theories/xtb_lot.py
+++ b/pygsm/level_of_theories/xtb_lot.py
@@ -6,7 +6,7 @@ from os import path
 import numpy as np
 import contextlib
 from xtb.interface import Calculator
-from xtb.utils import get_method
+from xtb.utils import get_method, get_solvent
 from xtb.interface import Environment
 from xtb.libxtb import VERBOSITY_FULL
 
@@ -41,6 +41,9 @@ class xTB_lot(Lot):
 
         calc.set_accuracy(self.xTB_accuracy)
         calc.set_electronic_temperature(self.xTB_electronic_temperature)
+
+        if self.solvent is not None:
+            calc.set_solvent(get_solvent(self.solvent))
         
         calc.set_output('lot_jobs_{}.txt'.format(self.node_id))
         res = calc.singlepoint()  # energy printed is only the electronic part

--- a/pygsm/wrappers/main.py
+++ b/pygsm/wrappers/main.py
@@ -69,6 +69,7 @@ def parse_arguments(verbose=True):
     parser.add_argument('-xTB_accuracy',type=float,default=1.0, help='xTB accuracy',required=False)
     parser.add_argument('-xTB_electronic_temperature',type=float,default=300.0, help='xTB electronic temperature',required=False)
     parser.add_argument('-xyz_output_format',type=str,default="molden",help='Format of the produced XYZ files',required=False)
+    parser.add_argument('-solvent',type=str,help='Solvent to use (xTB calculations only)',required=False)
     parser.add_argument('-linesearch', type=str, default='NoLineSearch', help='default: %(default)s',
                         choices=['NoLineSearch', 'backtrack'])
     parser.add_argument('-coordinate_type', type=str, default='TRIC', help='Coordinate system (default %(default)s)',
@@ -160,6 +161,7 @@ def parse_arguments(verbose=True):
         'xTB_Hamiltonian': args.xTB_Hamiltonian,
         'xTB_accuracy': args.xTB_accuracy,
         'xTB_electronic_temperature': args.xTB_electronic_temperature,
+        'solvent': args.solvent,
 
         # PES
         'PES_type': args.pes_type,
@@ -283,6 +285,8 @@ def create_lot(inpfileq: dict, geom):
             xTB_Hamiltonian=inpfileq['xTB_Hamiltonian'],
             xTB_accuracy=inpfileq['xTB_accuracy'],
             xTB_electronic_temperature=inpfileq['xTB_electronic_temperature'],
+            solvent=inpfileq['solvent'],
+            **lot_options,
                 )
     else:
         est_package = importlib.import_module("pygsm.level_of_theories." + lot_name.lower())


### PR DESCRIPTION
This commit adds the option to use solvation with the xTB levels of theory. There is no change to the calculation when no solvent is specified.

Also, I initially couldn't get the code working with xTB. Upon investigation, it seems that the `xTB_lot` class did not receive `**lot_options` like the others, and thus crashed. I added the options and everything seems to work. I'm guessing that it was a bug?