### PR TITLE
Update main_gsm.py

### DIFF
--- a/pyGSM/growing_string_methods/main_gsm.py
+++ b/pyGSM/growing_string_methods/main_gsm.py
@@ -12,13 +12,13 @@ try:
 except:
     from gsm import GSM
 
-from molecule.molecule import Molecule
-from utilities.nifty import printcool
-from utilities.manage_xyz import xyz_to_np
-from utilities import units
-from utilities import block_matrix
-from coordinate_systems import rotate
-from optimizers import eigenvector_follow
+from pyGSM.molecule.molecule import Molecule
+from pyGSM.utilities.nifty import printcool
+from pyGSM.utilities.manage_xyz import xyz_to_np
+from pyGSM.utilities import units
+from pyGSM.utilities import block_matrix
+from pyGSM.coordinate_systems import rotate
+from pyGSM.optimizers import eigenvector_follow
 import multiprocessing as mp
 from itertools import chain
 from copy import deepcopy


### PR DESCRIPTION
Please make this change. Using `pip install git+https://github.com/ZimmermanGroup/pyGSM.git' or `poetry add git+https://github.com/ZimmermanGroup/pyGSM.git` leads to the following import error: 
```
  from pyGSM.growing_string_methods import DE_GSM
  File "[path-to-pygsminstallation]/pyGSM/growing_string_methods/__init__.py", line 2, in <module>
    from .main_gsm import MainGSM
  File "[path-to-pygsminstallation]/pyGSM/growing_string_methods/main_gsm.py", line 15, in <module>
    from molecule.molecule import Molecule```

## Description
Will allow for bugless installation when using pip or poetry to install this package instead of having to git clone repo. 